### PR TITLE
Adding option to specify Module namespace.

### DIFF
--- a/T4TS.Example/Scripts/Api/T4TS.d.ts
+++ b/T4TS.Example/Scripts/Api/T4TS.d.ts
@@ -3,7 +3,7 @@
   Generated file
 ************************************************/
 
-module Api {
+module Api{
 
     /** Generated from T4TS.Example.Models.Barfoo **/
     export interface Barfoo {

--- a/T4TS.Example/Scripts/Api/T4TS.tt
+++ b/T4TS.Example/Scripts/Api/T4TS.tt
@@ -19,10 +19,11 @@
 /************************************************
   Generated file
 ************************************************/
+<# foreach(var tsInterfaceGroup in output.GroupBy(i => i.Module)) { #>
 
-module Api {
+module <#= tsInterfaceGroup.Key #>{
 
-<# foreach(var tsInterface in output) { #>
+<# foreach(var tsInterface in tsInterfaceGroup) { #>
     /** Generated from <#= tsInterface.FullName #> **/
     export interface <#= tsInterface.Name #> {
 <# foreach(var member in tsInterface.Members) { #>
@@ -34,7 +35,9 @@ module Api {
     }
 
 <# } #>
-}<#+ 
+}
+<# } #>
+<#+ 
 static DTE Dte;
 static Project Project;
 static string AppRoot;

--- a/T4TS.Example/Scripts/App/Test.js
+++ b/T4TS.Example/Scripts/App/Test.js
@@ -1,0 +1,18 @@
+var App;
+(function (App) {
+    var Test = (function () {
+        function Test() {
+            $.post('./example', {
+            }, function (data) {
+                alert(data.NestedObject.Name);
+                alert(data.NestedObject.Complex[1].Number.toString());
+                $.each(data.NestedObjectArr, function (i, v) {
+                    alert(v.DateTime);
+                });
+            });
+        }
+        return Test;
+    })();
+    App.Test = Test;    
+})(App || (App = {}));
+

--- a/T4TS.Example/Scripts/App/Test.min.js
+++ b/T4TS.Example/Scripts/App/Test.min.js
@@ -1,0 +1,1 @@
+var App;(function(n){var t=function(){function n(){$.post("./example",{},function(n){alert(n.NestedObject.Name),alert(n.NestedObject.Complex[1].Number.toString()),$.each(n.NestedObjectArr,function(n,t){alert(t.DateTime)})})}return n}();n.Test=t})(App||(App={}))

--- a/T4TS/AttributeDecoratedInstance.cs
+++ b/T4TS/AttributeDecoratedInstance.cs
@@ -11,6 +11,7 @@ namespace T4TS
     {
         public CodeNamespace Namespace { get; set; }
         public CodeType CodeType { get; set; }
+        public string Module { get; set; }
         public string TypescriptType { get; set; }
     }
 }

--- a/T4TS/CodeGenerator.cs
+++ b/T4TS/CodeGenerator.cs
@@ -13,6 +13,7 @@ namespace T4TS.Generator
     {
         public Project Project { get; private set; }
         private static readonly string AttributeFullName = typeof(TypeScriptInterfaceAttribute).FullName;
+        private static readonly string DefaultModuleName = "Api";
 
         private static readonly string[] genericCollectionTypeStarts = new string[] {
             "System.Collections.Generic.List<",
@@ -22,7 +23,6 @@ namespace T4TS.Generator
 
         public CodeGenerator(Project project)
         {
-
             this.Project = project;
         }
 
@@ -80,7 +80,8 @@ namespace T4TS.Generator
                             {
                                 CodeType = ct,
                                 Namespace = ns,
-                                TypescriptType = ct.Name
+                                TypescriptType = ct.Name,
+                                Module = GetAttributeModuleName(attr)
                             };
 
                             break;
@@ -90,12 +91,25 @@ namespace T4TS.Generator
             }
         }
 
+        private string GetAttributeModuleName(CodeAttribute codeAttribute)
+        {
+            foreach (CodeElement child in codeAttribute.Children)
+            {
+                EnvDTE80.CodeAttributeArgument property = (EnvDTE80.CodeAttributeArgument)child;
+                if (property.Name == "Module")
+                    return property.Value.Replace("\"","");
+            }
+
+            return DefaultModuleName;
+        }
+
         private TypeScriptInterface GetInterface(AttributeDecoratedInstance instance, TypeContext typeContext)
         {
             var tsInterface = new TypeScriptInterface
             {
                 FullName = instance.CodeType.FullName,
                 Name = instance.CodeType.Name,
+                Module = instance.Module,
                 Members = GetMembers(instance, typeContext).ToList()
             };
 

--- a/T4TS/TypeScriptInterface.cs
+++ b/T4TS/TypeScriptInterface.cs
@@ -10,6 +10,7 @@ namespace T4TS.Generator
     {
         public string Name { get; set; }
         public string FullName { get; set; }
+        public string Module { get; set; }
         public List<TypeScriptInterfaceMember> Members { get; set; }
         public string IndexerType { get; set; }
     }

--- a/T4TS/TypeScriptInterfaceAttribute.cs
+++ b/T4TS/TypeScriptInterfaceAttribute.cs
@@ -7,8 +7,16 @@ namespace T4TS
 {
     public class TypeScriptInterfaceAttribute: Attribute
     {
+        public string Module { get; set; }
+
         public TypeScriptInterfaceAttribute()
+            : this("Api")
         {
+        }
+
+        public TypeScriptInterfaceAttribute(string module) 
+        {
+            this.Module = module;
         }
     }
 }


### PR DESCRIPTION
Not completely satisfied with the magic string "Module" contained in this, but it's a start. Feel free to improve before merging in to master if you find anything that bothers you. :)

Usage: [TypeScriptInterface(Module="MyAwesomeModule")]

Specifying DefaultModuleName might seem redundant as it's already used in the default constructor, but it feels scary to not have anything there - you're the boss, you decide!
