### PR TITLE
Added IEnumerable to Generic collections

### DIFF
--- a/T4TS.Build/T4TS.tt
+++ b/T4TS.Build/T4TS.tt
@@ -759,7 +759,8 @@ public class InterfaceOutputAppender : OutputAppender<TypeScriptInterface>
         private static readonly string[] genericCollectionTypeStarts = new string[] {
             "System.Collections.Generic.List<",
             "System.Collections.Generic.IList<",
-            "System.Collections.Generic.ICollection<"
+            "System.Collections.Generic.ICollection<",
+            "System.Collections.Generic.IEnumerable<"
         };
 
         private static readonly string nullableTypeStart = "System.Nullable<";


### PR DESCRIPTION
so 
`public IEnumerable<SomeType> SomeProperty` will become `SomeProperty: SomeType[]` instead of `SomeProperty: any`
