### PR TITLE
C# Nullable != TypeScript optional

### DIFF
--- a/T4TS/Outputs/MemberOutputAppender.cs
+++ b/T4TS/Outputs/MemberOutputAppender.cs
@@ -17,7 +17,7 @@ namespace T4TS
         {
             AppendIndendation();
 
-            bool isOptional = member.Optional || (member.Type is NullableType);
+            bool isOptional = member.Optional;
             string type = member.Type.ToString();
 
             if (member.Type is BoolType)

--- a/build/T4TS.tt
+++ b/build/T4TS.tt
@@ -172,7 +172,7 @@ Project GetProjectContainingT4File(DTE dte) {
         {
             AppendIndendation();
 
-            bool isOptional = member.Optional || (member.Type is NullableType);
+            bool isOptional = member.Optional;
             string type = member.Type.ToString();
 
             if (member.Type is BoolType)


### PR DESCRIPTION
C# nullable members shouldn't be automatically made optional in the generated TypeScript interfaces as the two are not equivalent.  In TypeScript any type is essentially nullable as null or undefined are valid values for any type.  An optional property in TypeScript indicates that that the member may or may not actually be on the object.