### PR TITLE
Add support for converting IEnumerable<T> to T[].

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Specifications
    * `Nullable<T>` **=>** `T?`
    * A class marked with `[TypeScriptInterface]` **=>** lookup the generated TypeScript name
    * Otherwise **=>** `any`
-   * For `Collection<T>`, `List<T>`, `IList<T>` and `T[]` **=>** lookup type for `T` as above, and return `T[]`.
+   * For `IEnumerable<T>`, `Collection<T>`, `List<T>`, `IList<T>` and `T[]` **=>** lookup type for `T` as above, and return `T[]`.
 
  * Inheritance of interfaces is supported. If `Bar` inherits `Foo` in C# and both are marked with the `TypeScriptInterfaceAttribute`, the generated interface would be `interface Bar extends Foo {...`.
 

--- a/T4TS/TypeContext.cs
+++ b/T4TS/TypeContext.cs
@@ -15,7 +15,8 @@ namespace T4TS
         private static readonly string[] genericCollectionTypeStarts = new string[] {
             "System.Collections.Generic.List<",
             "System.Collections.Generic.IList<",
-            "System.Collections.Generic.ICollection<"
+            "System.Collections.Generic.ICollection<",
+            "System.Collections.Generic.IEnumerable<"
         };
 
         private static readonly string nullableTypeStart = "System.Nullable<";


### PR DESCRIPTION
Many of the fields/properties were IEnumerable<T>, not Collection, List, IList, []. This small change just supports IEnumerable<T>.