### PR TITLE
Classes would not be picked up if projects are organised in folders.

### DIFF
--- a/T4TS/Traversal/ProjectTraverser.cs
+++ b/T4TS/Traversal/ProjectTraverser.cs
@@ -39,6 +39,8 @@ namespace T4TS
 
                 if (pi.ProjectItems != null)
                     Traverse(pi.ProjectItems);
+                else if (pi.SubProject != null && pi.SubProject.ProjectItems != null)
+                    Traverse(pi.SubProject.ProjectItems);
             }
         }
     }


### PR DESCRIPTION
With the changes in version 2.2.0 that allows "any class in the solution with the TypeScriptInterface attribute to be generated", if projects are kept/organised in folders in a solution, no any class was being picked up and the output of T4TS was empty.

Getting the project traverser to look for ProjectItems in SubProject fixes this issue.