### PR TITLE
new feature: generate comments from C# source to the TS definitions

### DIFF
--- a/T4TS.Example/Models/Barfoo.cs
+++ b/T4TS.Example/Models/Barfoo.cs
@@ -3,10 +3,22 @@ using System.Collections.Generic;
 
 namespace T4TS.Example.Models
 {
+    /// <summary>
+    /// Barfoo has some comments!
+    /// <example>var bar = new Barfoo();</example>
+    /// </summary>
     [TypeScriptInterface(Module = "")]
     public class Barfoo
     {
+        /// <summary>
+        /// Well, this is a number
+        /// And has multiple lines of comment
+        /// "Nicely" formated
+        /// </summary>
         public int Number { get; set; }
+        /// <summary>
+        /// Okay, this has a single line of comment
+        /// </summary>
         public Inherited Complex { get; set; }
         public string Name { get; set; }
         public DateTime DateTime { get; set; }

--- a/T4TS.Example/T4TS.d.ts
+++ b/T4TS.Example/T4TS.d.ts
@@ -18,8 +18,20 @@
 
 // -- Begin global interfaces
     /** Generated from T4TS.Example.Models.Barfoo **/
+    /**  <summary>
+    * Barfoo has some comments!
+    * <example>var bar = new Barfoo();</example>
+    * </summary> */
     interface Barfoo {
+        /**  <summary>
+        * Well, this is a number
+        * And has multiple lines of comment
+        * "Nicely" formated
+        * </summary> */
         Number: number;
+        /**  <summary>
+        * Okay, this has a single line of comment
+        * </summary> */
         Complex: T4TS.OverridenName;
         Name: string;
         DateTime: string;
@@ -111,6 +123,12 @@ declare module T4TS {
         MyProperty: number;
         SomeDateTime: string;
     }
+    /** Generated from T4TS.Tests.Fixtures.Dictionary.DictionaryModel **/
+    export interface DictionaryModel {
+        IntKey: { [name: number]: T4TS.BasicModel};
+        StringKey: { [name: string]: T4TS.BasicModel};
+        [index: number]: T4TS.BasicModel;
+    }
     /** Generated from T4TS.Tests.Fixtures.Enumerable.EnumerableModel **/
     export interface EnumerableModel {
         NormalProperty: number;
@@ -120,6 +138,7 @@ declare module T4TS {
         InterfaceList: T4TS.BasicModel[];
         DeepArray: number[][];
         DeepList: number[][];
+        Generic: string[];
     }
     /** Generated from T4TS.Tests.Fixtures.ExternalProp.ExternalPropModel **/
     export interface ExternalPropModel {

--- a/T4TS/CodeTraverser.cs
+++ b/T4TS/CodeTraverser.cs
@@ -115,7 +115,9 @@ namespace T4TS
             var tsInterface = new TypeScriptInterface
             {
                 FullName = codeClass.FullName,
-                Name = GetInterfaceName(attributeValues)
+                Name = GetInterfaceName(attributeValues),
+                Comment = codeClass.Comment,
+                DocComment = codeClass.DocComment
             };
 
             TypescriptType indexedType;
@@ -210,7 +212,9 @@ namespace T4TS
                 Ignore = values.Ignore,
                 Type = (string.IsNullOrWhiteSpace(values.Type))
                     ? typeContext.GetTypeScriptType(getter.Type)
-                    : new InterfaceType(values.Type)
+                    : new InterfaceType(values.Type),
+                Comment = property.Comment,
+                DocComment = property.DocComment
             };
 
             if (member.Ignore)

--- a/T4TS/Outputs/InterfaceOutputAppender.cs
+++ b/T4TS/Outputs/InterfaceOutputAppender.cs
@@ -38,6 +38,10 @@ namespace T4TS
         private void BeginInterface(TypeScriptInterface tsInterface)
         {
             AppendIndentedLine("/** Generated from " + tsInterface.FullName + " **/");
+			
+			//replace NewLine characters, so multiline comments will align nicely, and don't stick to the begining of the lines...
+            if(!string.IsNullOrWhiteSpace(tsInterface.Comment)) { AppendIndentedLine("/**  " + tsInterface.Comment.Replace(Environment.NewLine, Environment.NewLine + new string(' ', BaseIndentation) + "* ") + " */"); }
+            if(!string.IsNullOrWhiteSpace(tsInterface.DocComment)) { AppendIndentedLine("/**  " + tsInterface.DocComment.Replace(Environment.NewLine, Environment.NewLine + new string(' ', BaseIndentation) + "* ") + " */"); }
 
             if (InGlobalModule)
                 AppendIndented("interface " + tsInterface.Name);

--- a/T4TS/Outputs/MemberOutputAppender.cs
+++ b/T4TS/Outputs/MemberOutputAppender.cs
@@ -15,6 +15,10 @@ namespace T4TS
 
         public override void AppendOutput(TypeScriptInterfaceMember member)
         {
+			//replace NewLine characters, so multiline comments will align nicely, and don't stick to the begining of the lines...
+            if(!string.IsNullOrWhiteSpace(member.Comment)) { AppendIndentedLine("/**  " + member.Comment.Replace(Environment.NewLine, Environment.NewLine + new string(' ', BaseIndentation) + "* ") + " */"); }
+            if(!string.IsNullOrWhiteSpace(member.DocComment)) { AppendIndentedLine("/**  " + member.DocComment.Replace(Environment.NewLine, Environment.NewLine + new string(' ', BaseIndentation) + "* ") + " */"); }
+
             AppendIndendation();
 
             bool isOptional = member.Optional;
@@ -27,7 +31,6 @@ namespace T4TS
                 else
                     type = "boolean";
             }
-
             Output.AppendFormat("{0}{1}: {2}",
                 member.Name,
                 (isOptional ? "?" : ""),

--- a/T4TS/Outputs/TypeScriptInterface.cs
+++ b/T4TS/Outputs/TypeScriptInterface.cs
@@ -11,6 +11,20 @@ namespace T4TS
     {
         public string Name { get; set; }
         public string FullName { get; set; }
+        
+        public string Comment { get; set; }
+
+        private string _docComment;
+        public string DocComment {
+          get { return _docComment; }
+          set {
+            if(value == null) { _docComment = null; }
+            //strip the '<doc> </doc>' xml tags
+            if(value.StartsWith("<doc>") && value.EndsWith("</doc>")) {
+              _docComment = value.Substring(5, value.Length - 11).Trim();
+            } else { _docComment = value; }
+          }
+        }
 
         public List<TypeScriptInterfaceMember> Members { get; set; }
         public TypescriptType IndexedType { get; set; }

--- a/T4TS/Outputs/TypeScriptInterfaceMember.cs
+++ b/T4TS/Outputs/TypeScriptInterfaceMember.cs
@@ -8,6 +8,20 @@ namespace T4TS
     public class TypeScriptInterfaceMember
     {
         public string Name { get; set; }
+
+        public string Comment { get; set; }
+
+        private string _docComment;
+        public string DocComment {
+          get { return _docComment; }
+          set {
+            if(value == null) { _docComment = null; }
+            //strip the '<doc> </doc>' xml tags
+            if(value.StartsWith("<doc>") && value.EndsWith("</doc>")) {
+              _docComment = value.Substring(5, value.Length - 11).Trim();
+            } else { _docComment = value; }
+          }
+        }
         public TypescriptType Type { get; set; }
         public bool Optional { get; set; }
         //public string FullName { get; set; }


### PR DESCRIPTION
Check T4TS.Example/Models/Barfoo.cs and T4TS.Example/T4TS.d.ts for an example


This commit does have some repetitive code, but couldn't pinpoint a "utility" class for the string trimming/modifying code. Of course having a utility class is bad by default...